### PR TITLE
fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ ENV HOST=0.0.0.0
 ENV PORT=5173
 ENV CONFIGURATION=development
 
-RUN npm build
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -19,23 +19,19 @@ USER_POOL_ID=<USER_POOL_ID>
 USER_POOL_CLIENT_ID=<USER_POOL_CLIENT_ID>
 ```
 
-2. **Build**
-
-```sh
-docker-compose build
-```
-
-3. **Start the development server**
+2. **Start the development server**
 
 ```sh
 docker-compose up
 ```
 
+- This command will build and start the application in the development environment.
 - Navigate to `http://localhost:5173/`. The application will automatically reload if you change any of the source files.
 
 ### Notes
 
 - The `scripts/set-env.cjs` script sets up your environment variables from `.env` when starting up the development server. After running `docker-compose up`, verify that the `environments.ts` file has been generated inside `src/environments` and is being loaded into `src/main.ts`.
+- Run `docker-compose down` when you are finished with the development server to ensure a clean environment.
 
 ## Running Unit Tests
 

--- a/angular.json
+++ b/angular.json
@@ -51,13 +51,7 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true,
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.development.ts"
-                }
-              ]
+              "sourceMap": true
             }
           },
           "defaultConfiguration": "production"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,13 @@ services:
   angular-platform:
     build:
       context: .
+      dockerfile: Dockerfile
     ports:
       - "5173:5173"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=5173
+      - CONFIGURATION=development
     volumes:
       - ./src:/app/src
+    command: npm start


### PR DESCRIPTION
* Removes file replacement in `angular.json` which was causing the build to fail by looking for a file that does not exist. (we are just using one environment for now)
* Docker now builds and starts the development server with `docker-compose up` (instead of having to separately run `docker-compose build` and `docker-compose up`)